### PR TITLE
カフェプログラムの修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
+require "debug"
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)
@@ -19,16 +20,23 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  input = gets.to_i 
+  is_collect_order = (input >= 1) && (input <= menus.count)
+  while !is_collect_order
+    puts"正しい番号でお願いします"
+    return take_order(menus)
+  end
+  order_number = input - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
 
+binding.break
 puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
 order1 = take_order(DRINKS)
 
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price] + FOODS[order2][:price]
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "debug"
+
 
 DRINKS = [
   { name: 'コーヒー', price: 300 },
@@ -31,7 +31,6 @@ def take_order(menus)
   order_number
 end
 
-binding.break
 puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
 order1 = take_order(DRINKS)
 


### PR DESCRIPTION
## やったこと
- カフェプログラムのバグ修正
  - 頼んだつもりのメニューが選択できない。
  - 最後の番号のメニューを選択するとエラーとなる。
  - お会計額が異様に高い。
  - 違う番号のドリンク、フードを注文したとき、お会計が正しくない。
    - 例: (1)コーヒー と (2)アップルパイを頼むと、お会計が意図した金額にならない。
- 動作確認
## 見て欲しいところ
- 手元で問題なく動作するか
- コードの中に致命的な不備がないか
- デバッグのコードは消してもいいのか
- バグが残っていないか、修正の意図はあっているかどうか

## 参考
実行結果のスクショ
<img width="447" alt="スクリーンショット 2023-06-01 18 33 29" src="https://github.com/fjordllc/bug_cafe/assets/50833174/4e594b49-f586-4dc6-8348-2b78577886a0">
